### PR TITLE
No parallel stl on apple-clang

### DIFF
--- a/src/FeatureUtils.cpp
+++ b/src/FeatureUtils.cpp
@@ -5,14 +5,22 @@
 #include <stdexcept>
 #include <random>
 #include <cfloat>       // FLT_MAX
+#if defined(__cpp_lib_parallel_algorithm)
 #include <execution>    // std::par_unseq
+#endif
 
 template<typename T>
 void NormVector(std::vector<T>& vec, T normVal){
 
+#if defined(__cpp_lib_parallel_algorithm)
     std::for_each(std::execution::par_unseq, std::begin(vec), std::end(vec), [normVal](auto& val) {
         val /= normVal;
     });
+#else
+    std::for_each(std::begin(vec), std::end(vec), [normVal](auto& val) {
+        val /= normVal;
+    });
+#endif
 
 }
 template void NormVector<float>(std::vector<float>& vec, float normVal);


### PR DESCRIPTION
Skip the parallel stl on apple for the 0.9 VIS release . 